### PR TITLE
Fix typo in Test for InTimerRater

### DIFF
--- a/src/graderPublic/java/projekt/h8/TutorTests_H8_InTimeRaterTest.java
+++ b/src/graderPublic/java/projekt/h8/TutorTests_H8_InTimeRaterTest.java
@@ -330,7 +330,7 @@ public class TutorTests_H8_InTimeRaterTest {
             OrderReceivedEvent.of(4, order5),
             DeliverOrderEvent.of(4, vehicle, neighborhood, order1),
             DeliverOrderEvent.of(4, vehicle, neighborhood, order2)
-        ), 7);
+        ), 4);
 
         order4.setActualDeliveryTick(27);
         order5.setActualDeliveryTick(27);

--- a/src/graderPublic/java/projekt/h8/TutorTests_H8_InTimeRaterTest.java
+++ b/src/graderPublic/java/projekt/h8/TutorTests_H8_InTimeRaterTest.java
@@ -242,7 +242,7 @@ public class TutorTests_H8_InTimeRaterTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"0, 1, 0.0", "20, 1, 1.0", "3, 100, 0.9675"})
+    @CsvSource({"0, 1, 0.0", "20, 1, 1.0", "3, 100, 0.99"})
     public void testAllOrdersTooEarly(long ignoredTicksOff, long maxTickOff, double expected) {
 
         Rater inTimeRate = InTimeRater.Factory.builder()
@@ -275,7 +275,7 @@ public class TutorTests_H8_InTimeRaterTest {
             OrderReceivedEvent.of(1, order4),
             DeliverOrderEvent.of(1, vehicle, neighborhood, order1),
             DeliverOrderEvent.of(1, vehicle, neighborhood, order2)
-        ), 11);
+        ), 1);
 
         order3.setActualDeliveryTick(10);
         order4.setActualDeliveryTick(10);

--- a/src/graderPublic/java/projekt/h8/TutorTests_H8_InTimeRaterTest.java
+++ b/src/graderPublic/java/projekt/h8/TutorTests_H8_InTimeRaterTest.java
@@ -242,7 +242,7 @@ public class TutorTests_H8_InTimeRaterTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"0, 1, 0.0", "20, 1, 1.0", "3, 100, 0.99"})
+    @CsvSource({"0, 1, 0.0", "20, 1, 1.0", "3, 100, 0.9675"})
     public void testAllOrdersTooEarly(long ignoredTicksOff, long maxTickOff, double expected) {
 
         Rater inTimeRate = InTimeRater.Factory.builder()


### PR DESCRIPTION
Es sieht so aus als hätte hier fälschlicherweise `11` für den Tick `1` gestanden. 
Das hat vielleicht auch das Ergebnis verfälscht, weshalb ich es zu `0.99` ändern würde. 
(Bei mir ergab es sich aus den 4 Ordern mit jeweils 5 Tick expected Intervals. Dabei 2mal 1 Tick und 2 mal 9 Tick Intervalle. -> 4 mal 4 Tick Differenz - 3 Tick ignore = 4 mal 1 Tick. 4 Tick von 4 * 100 maxTicks = 99%)